### PR TITLE
Add firstparty analytics

### DIFF
--- a/src/components/Footnote.tsx
+++ b/src/components/Footnote.tsx
@@ -5,6 +5,7 @@ import * as rx from 'rxjs/operators';
 import * as rxHooks from 'observable-hooks';
 
 import { createSafeContext, useSafeContext } from '@src/hooks/use-safe-context';
+import * as analytics from '@src/utils/analytics';
 
 const FootnoteContext = createSafeContext<{
   currentFootnote$: rxjs.Observable<CurrentFootnote>;
@@ -67,6 +68,10 @@ export const Container = ({ onShow, onHide, children, ...props }: ContainerProps
       isPersistent: currentFootnote?.isPersistent === true ? true : event.type === 'click',
     });
     onShow?.();
+
+    if (key && currentFootnote?.key !== key) {
+      analytics.track('Showed Footnote', { which: key });
+    }
   }, [onShow]);
 
   React.useEffect(() => {

--- a/src/components/TypeyText.tsx
+++ b/src/components/TypeyText.tsx
@@ -7,6 +7,7 @@ import * as windups from 'windups';
 import VisuallyHidden from '@reach/visually-hidden';
 
 import { isTouchDevice } from '@src/utils/is-touch-device';
+import * as analytics from '@src/utils/analytics';
 
 type Props = React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement> & {
   isPaused?: boolean;
@@ -151,6 +152,10 @@ export const Content = styled<Props & { innerRef: React.MutableRefObject<HTMLDiv
             event.preventDefault();
             event.stopPropagation();
           }),
+          rx.tap(() => analytics.track(
+            'Continued TypeyText',
+            { which: 'Main Page', fromNum: numCompleted },
+          )),
           rx.switchMap(() => {
             const willPlayCallbackResult = onChildWindupWillPlay?.(newNumCompleted);
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -8,8 +8,10 @@ const SCRIPT_SRCS = [
   // IFF dev: unsafe-eval
   ...(process.env.NODE_ENV === 'development'
     ? ['\'unsafe-eval\'', '\'unsafe-inline\'']
-    : []
+    : ['sha256-RxpNNTe7DYJZzQPNtsGFQ485xNNq4Ks28yzondu6J70='] // todo - hash this
   ),
+  // firstparty
+  'fp.bigcomputer.xyz',
   // fathom
   'paul-branch.bigcomputer.xyz',
 ];
@@ -20,6 +22,11 @@ export default class MyDocument extends Document {
       <Html lang="en">
         <Head>
           <meta httpEquiv="Content-Security-Policy" content={`script-src ${SCRIPT_SRCS.join(' ')}; object-src 'none'; base-uri 'none';`} />
+          <script type="application/javascript" dangerouslySetInnerHTML={{ __html: `
+            !function(){var t=window.firstparty=window.firstparty||[];if(!t.initialize){if(t.invoked)return void(window.console&&console.error&&console.error("Firstparty snippet included twice."));t.invoked=!0,t.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"],t.factory=function(r){return function(){var e=Array.prototype.slice.call(arguments);return e.unshift(r),t.push(e),t}};for(var r=0;r<t.methods.length;r++){var e=t.methods[r];t[e]=t.factory(e)}t.load=function(r,e,i){t._writeKey=r,t._host=e,t._firstpartyOptions=i;var a="/js/firstparty.min.js";void 0!==i&&void 0!==i.libraryPath&&(a=i.libraryPath);var o=document.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://"+e+a;var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(o,n)},t.SNIPPET_VERSION="0.1.0"}}();
+            firstparty.load("wmc8KThQ2MxPq7Vu", "fp.bigcomputer.xyz");
+            firstparty.page();
+          ` }} />
 
           <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favicon/apple-touch-icon.png" />
           <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon/favicon-32x32.png" />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 import React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 
@@ -8,7 +10,7 @@ const SCRIPT_SRCS = [
   // IFF dev: unsafe-eval
   ...(process.env.NODE_ENV === 'development'
     ? ['\'unsafe-eval\'', '\'unsafe-inline\'']
-    : ['sha256-RxpNNTe7DYJZzQPNtsGFQ485xNNq4Ks28yzondu6J70='] // todo - hash this
+    : ['sha256-GPegF5iJqpMso8+D7cth7iBWpfnPdlE7RsDl5OLKgEs='] // todo - hash this
   ),
   // firstparty
   'fp.bigcomputer.xyz',
@@ -22,11 +24,11 @@ export default class MyDocument extends Document {
       <Html lang="en">
         <Head>
           <meta httpEquiv="Content-Security-Policy" content={`script-src ${SCRIPT_SRCS.join(' ')}; object-src 'none'; base-uri 'none';`} />
-          <script type="application/javascript" dangerouslySetInnerHTML={{ __html: `
-            !function(){var t=window.firstparty=window.firstparty||[];if(!t.initialize){if(t.invoked)return void(window.console&&console.error&&console.error("Firstparty snippet included twice."));t.invoked=!0,t.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"],t.factory=function(r){return function(){var e=Array.prototype.slice.call(arguments);return e.unshift(r),t.push(e),t}};for(var r=0;r<t.methods.length;r++){var e=t.methods[r];t[e]=t.factory(e)}t.load=function(r,e,i){t._writeKey=r,t._host=e,t._firstpartyOptions=i;var a="/js/firstparty.min.js";void 0!==i&&void 0!==i.libraryPath&&(a=i.libraryPath);var o=document.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://"+e+a;var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(o,n)},t.SNIPPET_VERSION="0.1.0"}}();
-            firstparty.load("wmc8KThQ2MxPq7Vu", "fp.bigcomputer.xyz");
-            firstparty.page();
-          ` }} />
+          <script type="application/javascript" dangerouslySetInnerHTML={{ __html:
+            addFirstPartyTracking.toString()
+              .replace(/^[^\n]*\n/, '')
+              .replace(/\n[^\n]+$/, '')
+          }} />
 
           <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favicon/apple-touch-icon.png" />
           <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon/favicon-32x32.png" />
@@ -41,3 +43,15 @@ export default class MyDocument extends Document {
     );
   }
 }
+
+/* eslint-disable */
+function addFirstPartyTracking() {
+  !function(){const t=window.firstparty=window.firstparty||[];if(!t.initialize){if(t.invoked)return void(window.console&&console.error&&console.error('Firstparty snippet included twice.'));t.invoked=!0,t.methods=['trackSubmit','trackClick','trackLink','trackForm','pageview','identify','reset','group','track','ready','alias','debug','page','once','off','on','addSourceMiddleware','addIntegrationMiddleware','setAnonymousId','addDestinationMiddleware'],t.factory=function(r){return function(){const e=Array.prototype.slice.call(arguments);return e.unshift(r),t.push(e),t;};};for(let r=0;r<t.methods.length;r++){const e=t.methods[r];t[e]=t.factory(e);}t.load=function(r,e,i){t._writeKey=r,t._host=e,t._firstpartyOptions=i;let a='/js/firstparty.min.js';void 0!==i&&void 0!==i.libraryPath&&(a=i.libraryPath);const o=document.createElement('script');o.type='text/javascript',o.async=!0,o.src='https://'+e+a;const n=document.getElementsByTagName('script')[0];n.parentNode.insertBefore(o,n);},t.SNIPPET_VERSION='0.1.0';}}();
+  firstparty.load('wmc8KThQ2MxPq7Vu', 'fp.bigcomputer.xyz');
+
+  if (process.env.NODE_ENV !== 'development') {
+    firstparty.page();
+  }
+  document.cookie = `LastLoadedAt=${Date.now()}`;
+}
+/* eslint-enable */

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,8 @@ import * as Footnote from '@src/components/Footnote';
 import * as TypeyText from '@src/components/TypeyText';
 import * as BuyNow from '@src/components/BuyNow';
 
+import * as analytics from '@src/utils/analytics';
+
 const BuyButtonPosition = {
   NextToContent: 'is-next-to-content',
   UnderContent: 'is-below-content',
@@ -128,6 +130,7 @@ export default function HomePage(): JSX.Element {
   }, []);
 
   const onBuyButtonClick = React.useCallback((event) => {
+    analytics.track('Clicked CTA', { which: 'Buy Now' });
     alert('presales begin june 2022');
     requestAnimationFrame(() => event.target.blur());
   }, []);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -120,7 +120,7 @@ export default function HomePage(): JSX.Element {
     }
   }, [isShowingBuyNowButton]);
 
-  const onChildWindupCompleted = React.useCallback((childNum) => {
+  const onChildWindupCompleted = React.useCallback((childNum: number) => {
     setIsShowingBuyNowButton(true);
 
     if (childNum === 0) {
@@ -128,10 +128,10 @@ export default function HomePage(): JSX.Element {
     }
   }, []);
 
-  const onBuyButtonClick = React.useCallback((event) => {
+  const onBuyButtonClick = React.useCallback<React.MouseEventHandler>((event) => {
     analytics.track('Clicked CTA', { which: 'Buy Now' });
     alert('presales begin june 2022');
-    requestAnimationFrame(() => event.target.blur());
+    requestAnimationFrame(() => (event.target as HTMLElement).blur());
   }, []);
 
   React.useEffect(() => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { styled } from 'linaria/react';
-import * as Fathom from 'fathom-client';
 
 import { Avatar } from '@src/components/Avatar';
 import * as Footnote from '@src/components/Footnote';
@@ -113,7 +112,7 @@ export default function HomePage(): JSX.Element {
 
   const onHideFootnote = React.useCallback(() => setIsShowingFootnote(false), [setIsShowingFootnote]);
   const onShowFootnote = React.useCallback(() => setIsShowingFootnote(true), [setIsShowingFootnote]);
-  const onClickedJoinDiscord = React.useCallback(() => Fathom.trackGoal('VCJ8PHAD', 0), []);
+  const onClickedJoinDiscord = React.useCallback(() => analytics.track('Clicked CTA', { which: 'Join Discord' }), []);
 
   const onChildWindupWillPlay = React.useCallback(() => {
     if (buttonRef.current.classList.contains(BuyButtonPosition.UnderContent)) {

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -46,5 +46,6 @@ if (typeof window !== 'undefined') {
     });
 
   rxjs.fromEvent(window, 'beforeunload')
+    .pipe(rx.tap(() => cookies.setCookie('LastUnloadedAt', Date.now())))
     .subscribe(() => track('Page Unloaded'));
 }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,50 @@
+import * as rxjs from 'rxjs';
+import * as rx from 'rxjs/operators';
+
+import * as cookies from './cookies';
+
+declare const firstparty: {
+  track: (event: string, properties?: Record<string, unknown>, options?: null | never, callback?: () => unknown) => void;
+  page: (category?: string, name?: string, properties?: Record<string, unknown>, options?: null | never, callback?: () => unknown) => void;
+};
+
+let totalActiveTimeOnPage = 0;
+let lastUpdatedActiveTimeAt: number;
+let lastHiddenAt: number | null = null;
+
+export const track = (event: string, properties: Record<string, unknown> = {}) => {
+  updateActiveTime();
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log('track!!', event, { totalActiveTimeOnPage, ...properties });
+  } else {
+    firstparty.track(event, { totalActiveTimeOnPage, ...properties });
+  }
+};
+
+const updateActiveTime = (
+  since = lastUpdatedActiveTimeAt ?? cookies.getLatest().LastLoadedAt,
+  now = Date.now(),
+) => {
+  totalActiveTimeOnPage += now - since;
+  lastUpdatedActiveTimeAt = now;
+};
+
+if (typeof window !== 'undefined') {
+  rxjs.fromEvent(document, 'visibilitychange')
+    .pipe(rx.map(() => document.visibilityState))
+    .subscribe((newState) => {
+      if (newState === 'visible') {
+        if (lastHiddenAt) {
+          updateActiveTime(lastHiddenAt);
+        }
+
+        lastHiddenAt = null;
+      } else if (newState === 'hidden') {
+        lastHiddenAt = Date.now();
+      }
+    });
+
+  rxjs.fromEvent(window, 'beforeunload')
+    .subscribe(() => track('Page Unloaded'));
+}

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,9 +1,20 @@
 type Cookies = Record<string, unknown> & {
-  AnonymousId: string;
   LastLoadedAt: number;
+  LastUnloadedAt: number;
 };
+
+const MAX_COOKIE_AGE_IN_SECONDS = 60 /* secs */ * 60 /* mins */ * 24 /* hrs */ * 365;
 
 export const getLatest = (): Cookies => Object.fromEntries(
   document.cookie.split(';')
     .map((val) => val.trim().split('='))
 );
+
+export const setCookie = <Key extends keyof Cookies>(name: Key, value: Cookies[Key], expiresAt?: Date) => {
+  document.cookie = `${name}=${
+    typeof value === 'string' ? encodeURIComponent(value) : value
+  }; ${expiresAt
+    ? `expires=${expiresAt.toUTCString()}`
+    : `max-age=${MAX_COOKIE_AGE_IN_SECONDS}`
+  }; secure;`;
+};

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,0 +1,9 @@
+type Cookies = Record<string, unknown> & {
+  AnonymousId: string;
+  LastLoadedAt: number;
+};
+
+export const getLatest = (): Cookies => Object.fromEntries(
+  document.cookie.split(';')
+    .map((val) => val.trim().split('='))
+);


### PR DESCRIPTION
Now that we have a pretty website I'd like to learn about our visitors and sales funnel. [Firstparty](https://firstpartyhq.com/) is a new analytics provider that seems to work sort of like Segment, except uses a first-party cookie vs. proliferating pervasive pixels.

**TODO:**
- [ ] Why do the `setAnonymousId` calls seem to affect the underlying `firstparty.user().anonymousId()` value, get sent in the request payloads, but don't seem to show anywhere in the events manager?
    - [ ] Are the `setAnonymousId` calls even necessary in the first place? Looks like maybe these are obfuscated at rest, and this is what their Segments / Audiences are for?
- [ ] Will UTMs show up natively, or do I need to build that code too?